### PR TITLE
Added feature to skip translation for certain elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ const MyComponent = () => (
   <div>
     <h1>Hello, World!</h1>
     <p>This is a translatable text.</p>
+    <p class="no-translate">This is a translatable text.</p>
+    <code>This text will not be translated.</code>
+    <pre>This block will not be translated either.</pre>
   </div>
 );
 

--- a/src/hoc/withTranslation.js
+++ b/src/hoc/withTranslation.js
@@ -10,6 +10,13 @@ export const withTranslation = (Component) => {
 
     useEffect(() => {
       const translateElement = async (element) => {
+        // Skip translation for elements with a specific class or tag
+        if (element.classList && element.classList.contains('no-translate')) {
+          return;
+        }
+        if (element.tagName === 'CODE' || element.tagName === 'PRE') {
+          return; // Skip translation for <code> and <pre> tags
+        }
         if (element.nodeType === Node.TEXT_NODE && element.nodeValue.trim()) {
           const translated = await translateText(element.nodeValue, language);
           element.nodeValue = decodeHtmlEntities(translated);


### PR DESCRIPTION
### Added feature to skip translation for certain elements

This PR introduces a feature that allows elements with a specific class (`no-translate`) or certain tags (`<code>`, `<pre>`) to be excluded from translation. This ensures that elements like code blocks or static UI elements are not altered during translation.

- Modified the `withTranslation` HOC to check for `.no-translate` class and skip translation.
- Updated README.